### PR TITLE
gulp preview fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,11 @@
 
   },
   "scripts": {
-
+    "serve:before": "watch",
+    "emulate:before": "build",
+    "deploy:before": "build",
+    "build:before": "build",
+    "run:before": "build"
   },
   "keywords": [
     "owncloud",


### PR DESCRIPTION
This is a fix to enable ``gulp preview`` to run without errors.
I identified the solution via: https://github.com/ionic-team/ionic-cli/issues/1420#issuecomment-261893294

**Before:**
```
$ gulp preview
[15:54:04] Using gulpfile /var/www/owncloud/docs-ui/gulpfile.js
(node:15853) ExperimentalWarning: The http2 module is an experimental API.
[15:54:04] Starting 'build'...
[15:54:09] gulp-imagemin: Minified 7 images (saved 23.1 kB - 91.9%)
Node#moveTo was deprecated. Use Container#append.
[15:54:12] Finished 'build' after 8.17 s
[15:54:12] Starting 'build:preview'...
[15:54:12] 'build:preview' errored after 42 ms
[15:54:12] Error: ENOENT: no such file or directory, open 'public/index.html'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.readFileSync (fs.js:551:33)
    at module.exports (/var/www/owncloud/docs-ui/tasks/build-preview.js:38:18)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

**After:**
```
$ gulp preview
[16:09:35] Using gulpfile /var/www/owncloud/docs-ui/gulpfile.js
(node:16552) ExperimentalWarning: The http2 module is an experimental API.
[16:09:35] Starting 'build'...
[16:09:36] gulp-imagemin: Minified 7 images (saved 23.1 kB - 91.9%)
Node#moveTo was deprecated. Use Container#append.
[16:09:39] Finished 'build' after 4.29 s
[16:09:39] Starting 'build:preview'...
[16:09:39] Finished 'build:preview' after 397 ms
[16:09:39] Starting 'preview'...
[16:09:39] Starting server...
[16:09:41] Finished 'preview' after 1.46 s
[16:09:41] Server started http://0.0.0.0:5252
[16:09:41] Running server
```