### PR TITLE
Open "edit this page" link in a new tab/window

### DIFF
--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -6,6 +6,6 @@
 {{> breadcrumbs}}
 {{> page-versions}}
   {{#if page.editUrl}}
-  <div class="edit-this-page"><a href="{{page.editUrl}}">Edit this Page</a></div>
+  <div class="edit-this-page"><a href="{{page.editUrl}}" target="_blank">Edit this Page</a></div>
   {{/if}}
 </div>


### PR DESCRIPTION
This PR adjusts the "edit this page" link so that it opens in a new window, helping the user maintain context.