### PR TITLE
Style page images and image titles

### DIFF
--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -13,6 +13,23 @@ th {
 }
 
 /**
+ * Supplemental Image(-related) Styles
+ */
+div.paragraph div.title {
+  background-color: #f3f3f3;
+  color: #8c8c8c;
+  font-size: 85%;
+  font-style: italic;
+  padding: 2px;
+}
+
+div.paragraph p span.image img {
+  border-radius: 3px;
+  border: 1px solid #cecece;
+  padding: 2px;
+}
+
+/**
  * Supplemental Navigation Styles
  */
 li.nav-item.is-current-page.is-active a.nav-link {


### PR DESCRIPTION
The default styling of the image titles was hard to distinguish from normal text, so it was styled to help out, and the image element had a border added so that, if the image doesn't have a clear border, then it now has one. That will make it clear to know where the image stops and the rest of the page starts.