### PR TITLE
Update header font size and spacing

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -21,12 +21,34 @@
   color: #191919;
   font-weight: normal;
   line-height: 1.3;
-  margin: 1rem 0 0;
+  margin: 2rem 0 0;
   font-family: 'Raleway', sans-serif;
 }
 
+.doc h1 {
+  font-size: 2rem;
+  margin: 2rem 0 1.5rem;
+}
+
+.doc h2 {
+  font-size: 1.8rem;
+}
+
 .doc h3 {
+  font-size: 1.6rem;
   font-weight: 500;
+}
+
+.doc h4 {
+  font-size: 1.4rem;
+}
+
+.doc h5 {
+  font-size: 1.2rem;
+}
+
+.doc h6 {
+  font-size: 1.05rem;
 }
 
 .doc h1 > a.anchor,
@@ -258,11 +280,6 @@
 .doc .paragraph .image img {
   height: auto;
   max-width: 100%;
-}
-
-.doc > h1 {
-  font-size: 2rem;
-  margin: 2rem 0 1.5rem;
 }
 
 #preamble + .sect1,


### PR DESCRIPTION
To help make the headers more distinct, the font sizes have, mostly, been increased, and the top margin has also been increased. Hopefully, this should make them stand out more. Below are three examples of the adjusted header sizings and spacing.

### Example of h1 and h2

![h1 and h2](https://user-images.githubusercontent.com/196801/54021415-68271a80-4190-11e9-900d-d110d13f3b5a.png)

---

### Example of h1 and h5

![Example of h1 and h5](https://user-images.githubusercontent.com/196801/54021218-ecc56900-418f-11e9-9fb1-ff21fbe09098.png)

---

### Example of h1 and h6

![h1 and h6](https://user-images.githubusercontent.com/196801/54021428-6eb59200-4190-11e9-8511-4daa12320e1f.png)