### PR TITLE
Show the search from a width of 800px

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -36,7 +36,7 @@ body {
   padding: 0 0.375rem;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 800px) {
   .navbar-end > .navbar-item,
   .navbar-end .navbar-link {
     color: var(--color-navbar-text);
@@ -170,7 +170,7 @@ body {
   margin: 0.25rem 0;
 }
 
-@media screen and (max-width: 1319px) {
+@media screen and (max-width: 799px) {
   .navbar-brand .navbar-item {
     align-items: center;
     display: flex;
@@ -215,7 +215,7 @@ body {
   }
 }
 
-@media screen and (min-width: 1320px) {
+@media screen and (min-width: 800px) {
   .navbar,
   .navbar-menu,
   .navbar-end {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 800px) {
   .main-wrapper {
     display: flex;
   }

--- a/src/css/navigation-menu.css
+++ b/src/css/navigation-menu.css
@@ -14,7 +14,7 @@ html.is-clipped--nav {
   height: calc(100vh - var(--navbar-height) - var(--toolbar-height) - var(--drawer-height));
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1023px) {
   .navigation-menu {
     height: calc(100vh - var(--navbar-height) - var(--drawer-height));
   }

--- a/src/css/navigation-menu.css
+++ b/src/css/navigation-menu.css
@@ -14,7 +14,7 @@ html.is-clipped--nav {
   height: calc(100vh - var(--navbar-height) - var(--toolbar-height) - var(--drawer-height));
 }
 
-@media screen and (min-width: 1023px) {
+@media screen and (min-width: 800px) {
   .navigation-menu {
     height: calc(100vh - var(--navbar-height) - var(--drawer-height));
   }

--- a/src/css/navigation.css
+++ b/src/css/navigation.css
@@ -23,7 +23,7 @@
   }
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1023px) {
   .navigation-container {
     font-size: 0.8125rem;
     flex: none;
@@ -46,7 +46,7 @@
   }
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1023px) {
   .navigation {
     top: var(--navbar-height);
     box-shadow: none;

--- a/src/css/navigation.css
+++ b/src/css/navigation.css
@@ -23,7 +23,7 @@
   }
 }
 
-@media screen and (min-width: 1023px) {
+@media screen and (min-width: 800px) {
   .navigation-container {
     font-size: 0.8125rem;
     flex: none;
@@ -46,7 +46,7 @@
   }
 }
 
-@media screen and (min-width: 1023px) {
+@media screen and (min-width: 800px) {
   .navigation {
     top: var(--navbar-height);
     box-shadow: none;


### PR DESCRIPTION
Now that we have fewer menu points in the header we can adjust the minimum size up to which the search is displayed.

Possible fix for https://github.com/owncloud/docs-ui/issues/36