### PR TITLE
Fixed clicking on search result

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -361,11 +361,12 @@ body {
 }
 
 .search .results li {
-  padding: 0.5em 1em;
   border-bottom: 1px solid #ececec;
 }
 
 .search .results li a {
+  padding: 0.5em 1em;
+  display: block;
   color: initial;
 }
 

--- a/src/js/vendor/elastic.js
+++ b/src/js/vendor/elastic.js
@@ -82,6 +82,9 @@ $('#search').on('keyup focus', function () {
 })
 
 $('#search').on('blur', function () {
+  if ($('.search .results').is(':hover')) {
+    return
+  }
   $('.search .results').hide('')
   $('.search .animation').css('display', 'none')
 })


### PR DESCRIPTION
## Description
Added condition for hiding search results only if they are not hovered. If they were hidden too soon, the link was not triggered.

## Related issue
- Fixes: #49 