### PR TITLE
Enable support for tab blocks

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -12,4 +12,5 @@
 @import "header.css";
 @import "footer.css";
 @import "highlight.css";
+@import "tabs.css";
 @import "owncloud.css";

--- a/src/css/tabs.css
+++ b/src/css/tabs.css
@@ -1,0 +1,72 @@
+.tabset {
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
+.tabs ul {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0 -0.25rem 0 0;
+  padding: 0;
+}
+
+.tabs li {
+  align-items: center;
+  border-bottom: 0;
+  border: 1px solid #808080;
+  cursor: pointer;
+  display: flex;
+  font-weight: bold;
+  height: 2.5rem;
+  line-height: 1;
+  margin-right: 0.25rem;
+  padding: 0 1.5rem;
+  position: relative;
+}
+
+.tabs.ulist li {
+  margin-bottom: 0;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}
+
+.tabs li + li {
+  margin-top: 0;
+}
+
+.tabset.is-loading .tabs li:not(:first-child),
+.tabset:not(.is-loading) .tabs li:not(.is-active) {
+  background-color: #fafafa;
+  color: #8e8e8e;
+  font-weight: normal;
+}
+
+.tabset.is-loading .tabs li:first-child::after,
+.tabs li.is-active::after {
+  background-color: white;
+  content: "";
+  display: block;
+  height: 3px; /* Chrome doesn't always paint the line accurately, so add a little extra */
+  position: absolute;
+  bottom: -1.5px;
+  left: 0;
+  right: 0;
+}
+
+.tabset > .content {
+  border: 1px solid gray;
+  padding: 1.25rem;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}
+
+.tabset.is-loading .tab-pane:not(:first-child),
+.tabset:not(.is-loading) .tab-pane:not(.is-active) {
+  display: none;
+}
+
+.tab-pane > :first-child {
+  margin-top: 0;
+}

--- a/src/js/05-tabs.js
+++ b/src/js/05-tabs.js
@@ -1,0 +1,50 @@
+;(function () {
+  'use strict'
+
+  var hash = window.location.hash
+  find('.tabset').forEach(function (tabset) {
+    var active
+    var tabs = tabset.querySelector('.tabs')
+    if (tabs) {
+      var first
+      find('li', tabs).forEach(function (tab, idx) {
+        var id = (tab.querySelector('a[id]') || tab).id
+        if (!id) return
+        var pane = getPane(id, tabset)
+        if (!idx) first = { tab: tab, pane: pane }
+        if (!active && hash === '#' + id && (active = true)) {
+          tab.classList.add('is-active')
+          if (pane) pane.classList.add('is-active')
+        } else if (!idx) {
+          tab.classList.remove('is-active')
+          if (pane) pane.classList.remove('is-active')
+        }
+        tab.addEventListener('click', activateTab.bind({ tabset: tabset, tab: tab, pane: pane }))
+      })
+      if (!active && first) {
+        first.tab.classList.add('is-active')
+        if (first.pane) first.pane.classList.add('is-active')
+      }
+    }
+    tabset.classList.remove('is-loading')
+  })
+
+  function activateTab (e) {
+    var tab = this.tab
+    var pane = this.pane
+    find('.tabs li, .tab-pane', this.tabset).forEach(function (it) {
+      it === tab || it === pane ? it.classList.add('is-active') : it.classList.remove('is-active')
+    })
+    e.preventDefault()
+  }
+
+  function find (selector, from) {
+    return Array.prototype.slice.call((from || document).querySelectorAll(selector))
+  }
+
+  function getPane (id, tabset) {
+    return find('.tab-pane', tabset).find(function (it) {
+      return it.getAttribute('aria-labelledby') === id
+    })
+  }
+})()


### PR DESCRIPTION
A tab blocks extension is available for Antora that adds tab blocks support to AsciiDoc, which doesn't support it natively. For the extension to take effect, custom JS and CSS need to be integrated into the frontend; which is what this change does.

Below are two examples of what the tab blocks look like:

![Bildschirmfoto 2019-07-08 um 13 00 49](https://user-images.githubusercontent.com/196801/60808120-d227ee80-a187-11e9-8221-49ec81404ba0.png)
![Bildschirmfoto 2019-07-08 um 13 00 56](https://user-images.githubusercontent.com/196801/60808121-d227ee80-a187-11e9-8934-43ebfdd690e6.png)

The active tab has a white background and bolded black text. The inactive tab has a greyed background an white, normal text. The left-most tab is always enabled by default.

This change is part of implementing https://github.com/owncloud/docs/issues/1388.