### PR TITLE
Remove the IRC and Mailing List footer links

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -29,8 +29,6 @@
         <div class="footer-nav">
           <h4>Interact</h4>
           <ul id="menu-interact" class="menu">
-            <li class="menu-irc-channel"><a href="https://webchat.freenode.net/?channels=owncloud">IRC Channel</a></li>
-            <li class="menu-mailing-list"><a href="https://mailman.owncloud.org/mailman/listinfo/">Mailing List</a></li>
             <li class="menu-forums"><a href="https://central.owncloud.org">Forums</a></li>
             <li class="menu-bug-tracker"><a href="https://owncloud.org/community">Get involved</a></li>
             <li class="menu-promote"><a href="https://owncloud.org/promote/">Discuss ownCloud with others</a></li>


### PR DESCRIPTION
This PR removes the IRC and Mailing List footer links, as required by https://github.com/owncloud/docs/issues/1181.