### PR TITLE
Add JavaScript for Google Tag Manager

### DIFF
--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -24,10 +24,4 @@
 {{> main}}
 {{> footer}}
   </body>
-{{#if env.IS_DOCS}}
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXSDZWN"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-{{/if}}
 </html>

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -24,4 +24,10 @@
 {{> main}}
 {{> footer}}
   </body>
+{{#if env.IS_DOCS}}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXSDZWN"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+{{/if}}
 </html>

--- a/src/partials/head-google-tag-manager.hbs
+++ b/src/partials/head-google-tag-manager.hbs
@@ -1,0 +1,6 @@
+{{#if env.GOOGLE_TAG_MANAGER_ID}}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{env.GOOGLE_TAG_MANAGER_ID}}"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+{{/if}}

--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -18,3 +18,13 @@
     })();
   </script>
 {{/if}}
+
+{{#if env.IS_DOCS}}
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NXSDZWN');</script>
+<!-- End Google Tag Manager -->
+{{/if}}

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -1,1 +1,2 @@
+{{> head-google-tag-manager}}
 {{> header-content}}


### PR DESCRIPTION
The intent is to be able to use the Google Tag Manager in tandem with the Google Search Console to help manage site search results. This addition should enable Google Tag Manager support in the production docs.