### PR TITLE
Add Twitter and OpenGraph meta tags

### DIFF
--- a/src/partials/head-meta-opengraph.hbs
+++ b/src/partials/head-meta-opengraph.hbs
@@ -1,0 +1,6 @@
+<meta property="og:locale" content="en_us" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="{{page.title}}" />
+<meta property="og:description" content="{{page.description}}" />
+<meta property="og:url" content="{{page.canonicalUrl}}" />
+<meta property="og:site_name" content="{{#if site.title}}{{site.title}}{{/if}}" />

--- a/src/partials/head-meta-twitter.hbs
+++ b/src/partials/head-meta-twitter.hbs
@@ -1,0 +1,4 @@
+<meta name="twitter:site" content="@owncloud" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="{{page.title}}" />
+<meta name="twitter:description" content="{{page.description}}" />

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,0 +1,2 @@
+{{> head-meta-opengraph}}
+{{> head-meta-twitter}}


### PR DESCRIPTION
As part of https://github.com/owncloud/docs/issues/654, this PR adds Twitter and OpenGraph meta tags, where relevant, to the docs-ui. This change will work regardless of the documentation that they're attached to.