### PR TITLE
Add outdated documentation support

### DIFF
--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -103,6 +103,14 @@ blockquote::before {
   margin-top: 20px;
 }
 
+.outdated-documentation {
+  background-color: #f4f4f4;
+  border-radius: 5px;
+  border: 1px solid #efefef;
+  margin-top: 10px;
+  padding: 5px 5px 0 10px;
+}
+
 /**
  * Supplemental Responsive Styles
  */

--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -104,11 +104,15 @@ blockquote::before {
 }
 
 .outdated-documentation {
-  background-color: #f4f4f4;
-  border-radius: 5px;
-  border: 1px solid #efefef;
-  margin-top: 10px;
-  padding: 5px 5px 0 10px;
+  background-color: #0382c0;
+  padding: 10px 5px 10px 15px;
+  color: #fff;
+}
+
+.outdated-documentation a {
+  color: #fff;
+  font-weight: bold;
+  text-decoration: underline;
 }
 
 /**

--- a/src/helpers/neq.js
+++ b/src/helpers/neq.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (a, b) => a !== b

--- a/src/helpers/rewriteUrl.js
+++ b/src/helpers/rewriteUrl.js
@@ -1,0 +1,11 @@
+'use strict'
+
+/**
+ * This helper returns the URL of the current page in the latest version of the
+ * documentation, if it is in an outdated version of the documentation.
+ */
+module.exports = (pageUrl, latestVersion, currentVersion) => {
+  return (pageUrl.indexOf(currentVersion) !== -1)
+    ? pageUrl.replace(currentVersion, latestVersion)
+    : pageUrl
+}

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,3 +1,13 @@
+{{#if (and env.latestVersion page.version)}}
+  {{#if (neq env.latestVersion page.version) }}
+    <div class="outdated-documentation">
+      You are viewing an outdated version of the documentation.
+      Please use <a 
+        href="{{rewriteUrl @root.page.url env.latestVersion page.version}}"
+        >the latest version</a>.
+    </div>
+  {{/if}}
+{{/if}}
 <article class="doc">
   {{#if (eq page.layout '404')}}
     <h1>{{{or page.title 'Page Not Found'}}}</h1>
@@ -17,17 +27,6 @@
       </p>
     </div>
   {{else}}
-    {{#if (and env.latestVersion page.version)}}
-      {{#if (neq env.latestVersion page.version) }}
-        <div class="outdated-documentation">
-          You are viewing an outdated version of the documentation.
-          Please use <a 
-            href="{{rewriteUrl @root.page.url env.latestVersion page.version}}"
-            >the latest version</a>.
-        </div>
-      {{/if}}
-    {{/if}}
-
     {{#if page.title}}
       <h1>{{{page.title}}}</h1>
     {{/if}}

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -17,6 +17,17 @@
       </p>
     </div>
   {{else}}
+    {{#if (and env.latestVersion page.version)}}
+      {{#if (neq env.latestVersion page.version) }}
+        <div class="outdated-documentation">
+          You are viewing an outdated version of the documentation.
+          Please use <a 
+            href="{{rewriteUrl @root.page.url env.latestVersion page.version}}"
+            >the latest version</a>.
+        </div>
+      {{/if}}
+    {{/if}}
+
     {{#if page.title}}
       <h1>{{{page.title}}}</h1>
     {{/if}}


### PR DESCRIPTION
This relates to https://github.com/owncloud/docs/issues/1656. It adds the ability to determine if the current version of the documentation which the user is viewing is outdated. If it is, then a link to the current version of the page is visible.

Here is an example of what the link would look like.

![Screenshot_2020-04-15 ownCloud Documentation Overview](https://user-images.githubusercontent.com/196801/79326801-c1c15300-7f13-11ea-863b-19ac3ce7a809.png)