### PR TITLE
Integrate new showOutdatedNotice hbs plugin

### DIFF
--- a/src/helpers/showOutdatedNotice.js
+++ b/src/helpers/showOutdatedNotice.js
@@ -1,0 +1,21 @@
+'use strict'
+
+/**
+ * This helper determines if the outdated notification should be displayed or
+ * not.
+ */
+module.exports = (latestVersion, pageVersion) => {
+  if (!latestVersion || !pageVersion) {
+    return false
+  }
+
+  if (pageVersion === 'master') {
+    return false
+  }
+
+  if (pageVersion >= latestVersion) {
+    return false
+  }
+
+  return true
+}

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,12 +1,10 @@
-{{#if (and env.latestVersion page.version)}}
-  {{#if (neq env.latestVersion page.version) }}
-    <div class="outdated-documentation">
-      You are viewing an outdated version of the documentation.
-      Please use <a 
-        href="{{rewriteUrl @root.page.url env.latestVersion page.version}}"
-        >the latest version</a>.
-    </div>
-  {{/if}}
+{{#if (showOutdatedNotice env.latestVersion page.version)}}
+  <div class="outdated-documentation">
+    You are viewing an outdated version of the documentation.
+    Please use
+      <a href="{{rewriteUrl @root.page.url env.latestVersion page.version}}"
+         >the latest version</a>.
+  </div>
 {{/if}}
 <article class="doc">
   {{#if (eq page.layout '404')}}


### PR DESCRIPTION
This should both help simplify the logic for whether to show the outdated documentation notice or not, as well as to make it clearer. The addon rolls the logic of the existing combination of addons in to one, single addon. 