### PR TITLE
UI and domain TLD changes

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -6,7 +6,6 @@
           <h4>About ownCloud</h4>
           <ul id="menu-about" class="menu">
             <li class="menu-landing"><a href="https://owncloud.com/">The Secure Collaboration Platform</a></li>
-            <li class="menu-contribute"><a href="https://owncloud.com/contribute/">Contribute</a></li>
             <li class="menu-news"><a href="https://owncloud.com/news/">News</a></li>
             <li class="menu-privacy"><a href="https://owncloud.com/privacy-statement/">Privacy statement</a></li>
             <li class="menu-imprint"><a href="https://owncloud.com/imprint/">Imprint</a></li>
@@ -19,9 +18,9 @@
           <ul id="menu-support-and-documentation" class="menu">
             <li class="menu-faq"><a href="https://owncloud.com/faq/">FAQ</a></li>
             <li class="menu-help"><a href="https://owncloud.com/docs-guides/">Help</a></li>
-            <li class="menu-documentation"><a href="https://doc.owncloud.com">Documentation</a></li>
             <li class="menu-security"><a href="https://owncloud.com/security/">Security</a></li>
             <li class="menu-changelog"><a href="https://owncloud.com/changelog/">Changelog</a></li>
+            <li class="menu-get-started"><a href="https://owncloud.com/get-started/">Get started</a></li>
           </ul>
         </div>
       </div>
@@ -29,9 +28,11 @@
         <div class="footer-nav">
           <h4>Interact</h4>
           <ul id="menu-interact" class="menu">
-            <li class="menu-mailing-list"><a href="https://talk.owncloud.com" class="oc-footer-nav-link">Rocket.Chat</a></li>
-            <li class="menu-forums"><a href="https://central.owncloud.org" class="oc-footer-nav-link">Forums</a></li>
-            <li class="menu-promote"><a href="https://owncloud.com/promote/" class="oc-footer-nav-link">Discuss ownCloud with others</a></li>
+            <li class="menu-chat"><a href="https://talk.owncloud.com" class="oc-footer-nav-link">Rocket.Chat</a></li>
+            <li class="menu-forum"><a href="https://central.owncloud.org" class="oc-footer-nav-link">Forum</a></li>
+            <li class="menu-contribute"><a href="https://owncloud.com/contribute" class="oc-footer-nav-link">Contribute</a></li>
+            <li class="menu-customer-support"><a href="https://owncloud.com/support" class="oc-footer-nav-link">Customer support</a></li>
+
           </ul>
         </div>
       </div>

--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -5,11 +5,11 @@
         <div class="footer-nav">
           <h4>About ownCloud</h4>
           <ul id="menu-about" class="menu">
-            <li class="menu-enterprise"><a href="https://owncloud.com/">Enterprise</a></li>
-            <li class="menu-events"><a href="https://owncloud.org/events/">Events</a></li>
-            <li class="menu-news"><a href="https://owncloud.org/news/">News</a></li>
-            <li class="menu-privacy"><a href="https://owncloud.org/privacy-policy/">Privacy policy</a></li>
-            <li class="menu-imprint"><a href="https://owncloud.org/imprint/">Imprint</a></li>
+            <li class="menu-landing"><a href="https://owncloud.com/">The Secure Collaboration Platform</a></li>
+            <li class="menu-contribute"><a href="https://owncloud.com/contribute/">Contribute</a></li>
+            <li class="menu-news"><a href="https://owncloud.com/news/">News</a></li>
+            <li class="menu-privacy"><a href="https://owncloud.com/privacy-statement/">Privacy statement</a></li>
+            <li class="menu-imprint"><a href="https://owncloud.com/imprint/">Imprint</a></li>
           </ul>
         </div>
       </div>
@@ -17,11 +17,11 @@
         <div class="footer-nav">
           <h4>Resources</h4>
           <ul id="menu-support-and-documentation" class="menu">
-            <li class="menu-faq"><a href="https://owncloud.org/faq/">FAQ</a></li>
-            <li class="menu-help"><a href="https://owncloud.org/help/">Help</a></li>
-            <li class="menu-documentation"><a href="https://doc.owncloud.org">Documentation</a></li>
-            <li class="menu-security"><a href="https://owncloud.org/security/">Security</a></li>
-            <li class="menu-changelog"><a href="https://owncloud.org/changelog/">Changelog</a></li>
+            <li class="menu-faq"><a href="https://owncloud.com/faq/">FAQ</a></li>
+            <li class="menu-help"><a href="https://owncloud.com/docs-guides/">Help</a></li>
+            <li class="menu-documentation"><a href="https://doc.owncloud.com">Documentation</a></li>
+            <li class="menu-security"><a href="https://owncloud.com/security/">Security</a></li>
+            <li class="menu-changelog"><a href="https://owncloud.com/changelog/">Changelog</a></li>
           </ul>
         </div>
       </div>
@@ -31,14 +31,13 @@
           <ul id="menu-interact" class="menu">
             <li class="menu-mailing-list"><a href="https://talk.owncloud.com" class="oc-footer-nav-link">Rocket.Chat</a></li>
             <li class="menu-forums"><a href="https://central.owncloud.org" class="oc-footer-nav-link">Forums</a></li>
-            <li class="menu-bug-tracker"><a href="https://owncloud.org/community" class="oc-footer-nav-link">Get involved</a></li>
-            <li class="menu-promote"><a href="https://owncloud.org/promote/" class="oc-footer-nav-link">Discuss ownCloud with others</a></li>
+            <li class="menu-promote"><a href="https://owncloud.com/promote/" class="oc-footer-nav-link">Discuss ownCloud with others</a></li>
           </ul>
         </div>
       </div>
     </div>
     <p>
-      &copy; Copyright 2011-2018, The ownCloud developers.
+      &copy; Copyright 2011-2021, The ownCloud developers.
     </p>
   </div>
 </footer>

--- a/src/partials/header-nav.hbs
+++ b/src/partials/header-nav.hbs
@@ -1,2 +1,3 @@
-<a class="navbar-item" href="https://owncloud.org/">Community Edition</a>
-<a class="navbar-item" href="https://owncloud.com/">Enterprise Edition</a>
+{{! Community and Enterprise do not longer exist in that form, commenting out}
+{{! <a class="navbar-item" href="https://owncloud.org/">Community Edition</a>}}
+{{! <a class="navbar-item" href="https://owncloud.com/">Enterprise Edition</a>}}


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3794 (Remove Community/Enterprise edition links)

Look in particular at the headline and the footer:
* **Headline** Community and Enterprise text is now removed
I have not removed the `header-nav.hbs` file but commented the content. This enables us the easily add other things if we want to.
* **Footer**
** Cleanup of items and links
** Changed link names and links where necessary as the old names were pointing to redirected pages (all tested)
** Fixed all TLD´s from .org to .com where appropriate (the only one remained was central)
** Updated the copyright time to 2021

The screenshot below is a build from docs running:
`yarn antora-local --ui-bundle-url ../docs-ui/build/ui-bundle.zip`

![image](https://user-images.githubusercontent.com/3321281/125595732-b2811de3-480c-4f7f-a1f3-c7cee781331b.png)

**Note because of** #311 
I temporarily set `js-yarn` to a former working release to test if the preview here looks fine. This change is NOT included in the PR.

Before merging, I would like to hear if we want to add/change other items - ideas/suggestions welcomed 😃 