### PR TITLE
Fix: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load in…

### DIFF
--- a/tasks/build-preview.js
+++ b/tasks/build-preview.js
@@ -46,7 +46,7 @@ function loadSampleUiModel(siteSrc) {
   return promisify(fs.readFile)(
     path.join(siteSrc, "ui-model.yml"),
     "utf8"
-  ).then((contents) => yaml.safeLoad(contents));
+  ).then((contents) => yaml.load(contents));
 }
 
 function registerPartials(src) {


### PR DESCRIPTION
…stead, which is now safe by default.

This is a temporary fix for #311 (yarn run --> preview errors).

With this fix, you can now use `yarn preview` as intended and free of errors.

The long term fix is to update the environment according the guidelines at https://docs.antora.org/antora-ui-default/
