### PR TITLE
Make a conditional noindex meta directive

### DIFF
--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    {{#if page.attributes.noindex}}
+    <meta name="robots" content="noindex,nofollow">
+    {{/if}}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} :: {{site.title}}{{/if}}</title>


### PR DESCRIPTION
In Antora, you can create custom page attributes, see:
https://docs.antora.org/antora/2.3/page/page-attributes/#custom-attribute

These page attributes can be set in `site.yml` (global), in `antora.yml` (for a particular version) or on a `page` level. Compared to other attributes, these are available to the UI which can be used there to be either printed or for conditional html code.

The latter is being used to add a conditional meta tag `noindex,nofollow` for robots.

When in any of our documentations according the description above the attribute `page-noindex` is set (it just needs to be not empty), the page rendered will get the meta tag set.

This is necessary eg for the occ commands which are generated by including single files. Antora not only renders the final page, but also all including pages, even they are not linked anywhere. Crawlers find and provide them to searchers. With this mechanism, we instruct crawlers not to do so for marked pages returning only real content.

In addition, when adding the attribute to a branch in `antora.yml`, we can mark a whole branch not to be indexed. This will be used to instruct crawlews to ONLY render the `latest` (stable) branch and not `next` or `stable-1`.  Any search results will therefore only return results for the actual stable branch - when the site gets re-crawled !

This is the UI part of the fix for https://github.com/owncloud/docs/issues/4032 (Assign defined pages a noindex attribute)

Note: I did a lot of testing not only in the UI part here, but also in docs with various scenarious using the attribute on the page and version level.

@xoxys fyi