### PR TITLE
fix: replace deprecated hljs.initHighlighting()

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -3,4 +3,4 @@
   <script src="{{uiRootPath}}/js/vendor/elastic.js"></script>
 {{/if}}
 <script src="{{uiRootPath}}/js/vendor/highlight.js"></script>
-<script>hljs.initHighlighting()</script>
+<script>hljs.highlightAll()</script>


### PR DESCRIPTION
Deprecated since highlight.js v10.x