### PR TITLE
Fix certificate issue

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -10,7 +10,7 @@ def main(ctx):
         "steps": [
             {
                 "name": "Cache restore",
-                "image": "plugins/s3-cache:1",
+                "image": "plugins/s3-cache",
                 "pull": "always",
                 "settings": {
                     "endpoint": {
@@ -51,7 +51,7 @@ def main(ctx):
             },
             {
                 "name": "Cache rebuild",
-                "image": "plugins/s3-cache:1",
+                "image": "plugins/s3-cache",
                 "pull": "always",
                 "settings": {
                     "endpoint": {
@@ -76,7 +76,7 @@ def main(ctx):
             },
             {
                 "name": "Cache Flush",
-                "image": "plugins/s3-cache:1",
+                "image": "plugins/s3-cache",
                 "pull": "always",
                 "settings": {
                     "endpoint": {
@@ -99,7 +99,7 @@ def main(ctx):
             },
             {
                 "name": "Upload artifact",
-                "image": "plugins/s3:1",
+                "image": "plugins/s3",
                 "pull": "always",
                 "settings": {
                     "endpoint": "https://minio.owncloud.com",


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-ui/issues/345 (CI feedbacks x509: certificate has expired or is not yet valid)

Replacing
`plugins/s3-cache:1` with `plugins/s3-cache`
and
`plugins/s3:1` with `plugins/s3`
in the Drone config file.

@EParzefall @phil-davis fyi