### PR TITLE
Support the opengraph image meta tag

### DIFF
--- a/src/helpers/contains.js
+++ b/src/helpers/contains.js
@@ -1,16 +1,40 @@
 "use strict";
 
-module.exports = (collection, value, startIndex, options) => {
-  if (typeof startIndex === "object") {
-    options = startIndex;
-    startIndex = undefined;
+module.exports = (needle, haystack, options) => {
+// searches for a needle in haystack
+// mandatory arguments are needle and haystack
+// optional named arguments like "startIndex" and "word" are in options.hash.name
+// startIndex is only for indexOf
+// word is only to go for whole words. blanks and commas separates words (regex \b)
+// word just needs to have a value which is converted to true (set) or false (absent)
+
+  var startIndex;
+  var word = false;
+
+  if (typeof options.hash.startIndex !== "undefined") {
+    startIndex = options.hash.startIndex;
+    if (!Number.isInteger(startIndex)) {
+      startIndex = undefined;
+    }
   }
-  return contains(collection, value, startIndex);
+  if (typeof options.hash.word !== "undefined") {
+    word = options.hash.word;
+  }
+
+  return contains(needle, haystack, startIndex, word);
 };
 
-function contains(val, obj, start) {
-  if (val == null || obj == null || isNaN(val.length)) {
+function contains(needle, haystack, startIndex, word) {
+  if (needle == null || haystack == null || isNaN(needle.length)) {
     return false;
   }
-  return val.indexOf(obj, start) !== -1;
+
+  if (word) {
+    var regex = new RegExp("\\b" + needle + "\\b", "g");
+    // no matches gives you null, which is converted to false
+    // one or more matches gives you an array, which is converted to true
+    return !!haystack.match(regex);
+  } else {
+    return haystack.indexOf(needle, startIndex) !== -1;
+  }
 }

--- a/src/partials/head-meta-opengraph.hbs
+++ b/src/partials/head-meta-opengraph.hbs
@@ -1,6 +1,12 @@
-<meta property="og:locale" content="en_us" />
-<meta property="og:type" content="article" />
-<meta property="og:title" content="{{page.title}}" />
-<meta property="og:description" content="{{page.description}}" />
-<meta property="og:url" content="{{page.canonicalUrl}}" />
-<meta property="og:site_name" content="{{#if site.title}}{{site.title}}{{/if}}" />
+    <meta property="og:locale" content="en_us" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="{{page.title}}" />
+    <meta property="og:description" content="{{page.description}}" />
+    <meta property="og:url" content="{{page.canonicalUrl}}" />
+    <meta property="og:site_name" content="{{#if site.title}}{{site.title}}{{/if}}" />
+{{#if (contains page.component.name page.attributes.component-build-list word=true)}}
+    <meta property="og:image" content="{{site.url}}/opengraph-{{page.component.name}}.png" />
+{{else}}
+    <meta property="og:image" content="{{site.url}}/opengraph-default.png" />
+{{/if}}
+    <meta property="og:image:alt" content="The {{page.component.title}} documentation" />

--- a/src/partials/head-meta-twitter.hbs
+++ b/src/partials/head-meta-twitter.hbs
@@ -1,4 +1,4 @@
-<meta name="twitter:site" content="@owncloud" />
-<meta name="twitter:card" content="summary" />
-<meta name="twitter:title" content="{{page.title}}" />
-<meta name="twitter:description" content="{{page.description}}" />
+    <meta name="twitter:site" content="@owncloud" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="{{page.title}}" />
+    <meta name="twitter:description" content="{{page.description}}" />


### PR DESCRIPTION
Referencing:
https://github.com/owncloud/docs-ui/issues/396 (Revise head-meta-opengraph.hbs)
https://github.com/owncloud/docs/pull/4639 (Add attribute necessary for embedding opengraph images in docs-ui automatically)

This PR adds opengrap images _automagically_ dependent on the docs product.
Before merging this PR, the refrerenced docs PR should get merged to make the necessary attribute availabe.

* Improving the `contains.js` script to cover pure contain matches and word-contain matches
The latter is used for og:image. Note that the js code adoption for handelbars drove me nuts and has been tested intensively
* Fixing the intend of opengrap and twitter so that the output is aligned. Used for better readaility
* Adding handlebar code to the template to add `og:image` automatically based on the component name including a fallback if no match has been found

Examples:

**Server**
```
    <meta property="og:image" content="https://doc.owncloud.com/opengraph-server.png" />
    <meta property="og:image:alt" content="The ownCloud Server documentation" />
```
**Desktop**
```
    <meta property="og:image" content="https://doc.owncloud.com/opengraph-desktop.png" />
    <meta property="og:image:alt" content="The Desktop Client documentation" />
```
**Branding**
```
    <meta property="og:image" content="https://doc.owncloud.com/opengraph-default.png" />
    <meta property="og:image:alt" content="The Branded Clients documentation" />
```
Note that Branding does not have an own entry in the attributes list, therefore the default image is used. The Branding content will be integrated soon into the particular client documentation.