### PR TITLE
Prefill the og:description with the page title

### DIFF
--- a/src/partials/head-meta-opengraph.hbs
+++ b/src/partials/head-meta-opengraph.hbs
@@ -1,7 +1,7 @@
     <meta property="og:locale" content="en_us" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="{{page.title}}" />
-    <meta property="og:description" content="{{page.description}}" />
+    <meta property="og:description" content="{{page.title}}" />
     <meta property="og:url" content="{{page.canonicalUrl}}" />
     <meta property="og:site_name" content="{{#if site.title}}{{site.title}}{{/if}}" />
 {{#if (contains page.component.name page.attributes.component-build-list word=true)}}


### PR DESCRIPTION
The page description was empty in 99% of the cases, causing hint notes under the image to display a desctiption is missing. To temporarily fix this, the page title is added which is present in all cases.

On a longer view, this should be changed to a real brief description which then could be reused for google search. See details in the referenced issue https://github.com/owncloud/docs-ui/issues/396 (Revise head-meta-opengraph.hbs)

