### PR TITLE
Remove unused keys (cleanup)

### DIFF
--- a/src/css/navigation-explore.css
+++ b/src/css/navigation-explore.css
@@ -92,12 +92,6 @@
   font-weight: 500;
 }
 
-/*
-.navigation-explore .component .is-latest a::after {
-  content: " (latest)";
-}
-*/
-
 .navigation-explore .component .version + .version {
   padding-left: 0.375em;
 }

--- a/src/js/vendor/elastic.js
+++ b/src/js/vendor/elastic.js
@@ -45,7 +45,7 @@ $('#search').on('keyup focus', function () {
         context.matches.push({
           url: hit._source.url,
           component: hit._source.component,
-          version: hit._source.version === 'master' ? 'latest' : hit._source.version,
+          version: hit._source.version,
           head: hit._source.title,
           body: hit._source.text.substr(0, 100) + ' ...',
           score: Math.round(hit._score),

--- a/src/partials/navigation-explore.hbs
+++ b/src/partials/navigation-explore.hbs
@@ -14,7 +14,6 @@
           {{#each ./versions}}
             <li class="version
               {{~#if (and (eq ../this @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
-              {{~#if (eq this ../latestVersion)}} is-latest{{/if}}">
               <a href="{{{relativize @root.page.url ./url}}}">{{./version}}</a>
             </li>
           {{/each}}


### PR DESCRIPTION
Remove unused `latest` keys

Note in `elastic.js`, the value of `master` in `source.version` was legacy. We have `next` in all components and this is not `latest`.

An independent PR fixing `.drone.star` in `docs` will be created asap.

@xoxys fyi