### PR TITLE
favicon update preperation and highlight.js fix

### DIFF
--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -39,7 +39,7 @@ var hljs = (window.hljs = require('highlight.js/lib/core'))
   hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
   hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
   ;[].slice.call(document.querySelectorAll('pre code.hljs')).forEach(function (node) {
-    hljs.highlightBlock(node)
+    hljs.highlightElement(node)
   })
 })()
 

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -25,8 +25,8 @@
     <link rel="icon" href="/favicon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-    <meta name="msapplication-TileColor" content="#da532c">
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="black">
+    <meta name="msapplication-TileColor" content="#001840">
     <meta name="theme-color" content="#ffffff">
 {{> head}}
   </head>

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -21,6 +21,13 @@
     {{/if}}
     <link rel="stylesheet" href="{{uiRootPath}}/css/site.css">
     <link rel="manifest" href="/manifest.json">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" href="/favicon.svg">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+    <meta name="msapplication-TileColor" content="#da532c">
+    <meta name="theme-color" content="#ffffff">
 {{> head}}
   </head>
   <body class="article">


### PR DESCRIPTION
This PR
* fixes a highlight.js issue replacing a deprecated command (seen in the error log in the browser)
* prepares for updated favicons requested by marketing
Note, with using this, Google will now use a favicon in the search results

The necessary favicon file update will follow asap in the docs repo
