### PR TITLE
Fix and improve highlighting with highlight.js

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -465,9 +465,11 @@
   display: flex;
   visibility: hidden;
   position: absolute;
-  top: 0.25rem;
+  /* move things up for more distance, original top: 0.25rem; */
+  top: -0.5rem;
   right: 0.5rem;
-  color: var(--pre-annotation-font-color);
+  /* same color as in css/highlight.css hljs-built_in */
+  color: #0086b3;
   font-family: var(--body-font-family);
   font-size: calc(13.5 / var(--rem-base) * 1rem);
   line-height: 1;
@@ -551,6 +553,13 @@
   transition: none;
 }
 
+/* When using language console, a bash prompt (like > or $ or % or # or [test@ubuntu ~]$ ect.)
+ * will activate the meta css tag which results that this part can`t be selected manually in the 
+ * browser. This is also true up to 3 leading blanks at the beginning and then a prompt symbol!
+ * Rule: if the text to highlight starts with a bash prompt, choose shell (or console),
+ * otherwise choose bash. Using console but the line does not start with a bash prompt,
+ * highlighting will not work. Therefore check the language used carefully.
+*/
 .doc .language-console .hljs-meta {
   user-select: none;
 }

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -554,10 +554,10 @@
 }
 
 /* When using language console, a bash prompt (like > or $ or % or # or [test@ubuntu ~]$ ect.)
- * will activate the meta css tag which results that this part can`t be selected manually in the 
- * browser. This is also true up to 3 leading blanks at the beginning and then a prompt symbol!
+ * will activate the meta css tag which prevents that the prompt being copied and pasted manually in the 
+ * browser. This is also true for up to 3 leading blanks at the beginning and then a prompt symbol!
  * Rule: if the text to highlight starts with a bash prompt, choose shell (or console),
- * otherwise choose bash. Using console but the line does not start with a bash prompt,
+ * otherwise choose bash. If you use console but the line does not start with a bash prompt,
  * highlighting will not work. Therefore check the language used carefully.
 */
 .doc .language-console .hljs-meta {

--- a/src/css/highlight.css
+++ b/src/css/highlight.css
@@ -1,4 +1,5 @@
 /*! GitHub style for highlight.js (c) Vasily Polovnyov <vast@whiteants.net> */
+
 /*
 .hljs {
   display: block;

--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -1,6 +1,11 @@
 ;(function () {
   'use strict'
 
+// the following are additional keywords to be highlighted, particulary when using bash
+const CUSTOM_KEYWORDS = ['occ', 'apt', 'apt-get', 'systemctl', 'service', 'sudo',
+'dpkg', 'wget', 'tar', 'mysql', 'php', 'grep', 'pecl', 'pear', 'make', 
+'phpenmod', 'phpdismod', 'a2enmod', 'a2dismod', 'a2ensite', 'a2dissite'];
+
 var hljs = (window.hljs = require('highlight.js/lib/core'))
   hljs.registerLanguage('apache', require('highlight.js/lib/languages/apache'))
   hljs.registerLanguage('asciidoc', require('highlight.js/lib/languages/asciidoc'))
@@ -38,6 +43,21 @@ var hljs = (window.hljs = require('highlight.js/lib/core'))
   hljs.registerLanguage('swift', require('highlight.js/lib/languages/swift'))
   hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
   hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
+
+/* Add the additional keywords to the bash language
+ * Refernces https://github.com/highlightjs/highlight.js/wiki/Adding-keywords-to-a-language-at-runtime
+ * Layout used and defined in highlight.css at .hljs-built_in
+*/
+  hljs.getLanguage('bash').keywords.built_in.push(...CUSTOM_KEYWORDS);
+  // console.log(hljs.getLanguage('bash').keywords);
+
+/* To eliminate the security messages in the browser telling:
+ * "One of your code blocks includes unescaped HTML. This is a potentially serious security risk"
+ * See: https://github.com/highlightjs/highlight.js/wiki/security
+ * A hljs command has been added in partials/footer-scripts.hbs
+ * hljs.configure({ ignoreUnescapedHTML: true })
+ * This is not a security issue for us as we have a static site
+*/
   ;[].slice.call(document.querySelectorAll('pre code.hljs')).forEach(function (node) {
     hljs.highlightElement(node)
   })

--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -45,7 +45,7 @@ var hljs = (window.hljs = require('highlight.js/lib/core'))
   hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
 
 /* Add the additional keywords to the bash language
- * Refernces https://github.com/highlightjs/highlight.js/wiki/Adding-keywords-to-a-language-at-runtime
+ * References: https://github.com/highlightjs/highlight.js/wiki/Adding-keywords-to-a-language-at-runtime
  * Layout used and defined in highlight.css at .hljs-built_in
 */
   hljs.getLanguage('bash').keywords.built_in.push(...CUSTOM_KEYWORDS);

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -4,3 +4,4 @@
 {{/if}}
 <script src="{{uiRootPath}}/js/vendor/highlight.js"></script>
 <script>hljs.highlightAll()</script>
+<script>hljs.configure({ ignoreUnescapedHTML: true })</script>


### PR DESCRIPTION
References: https://github.com/owncloud/docs-server/issues/94 ([QA] Manual copy / paste misses redirects)
References: https://github.com/owncloud/docs/pull/4707 (Add info for the correct use of the source langauge)

**Description:**

* When using a language for examples (Antora source block), it is crucial to use the correct one. There is a big difference between using `console` (shell.js) and `bash` (bash.js). While `bash` highlights any recognized bash keyword word from the beginning and let this also be selectable via CSS in the browser, `console` _requires_ mandatory a bash promt at the beginning to highlight bash keywords correctly - but additionally disables the bash prompt as selectable component in the browser
* The color of the language selected is now the same color as a bash keyword, which makes the language much better distinctable from the below example block
* The language selected + the copy symbol are moved up a bit to make it not that close to the example block
* Additional keywords are added dynamically to the bash language reflecting available commands when a application is installed providing these commands like `phpen/dismod` or `wget` ect, see: [Adding Keywords to a Language at Startup](https://github.com/highlightjs/highlight.js/wiki/Adding-keywords-to-a-language-at-startup). Some keywords are added in advance like the `a2xxx` commands and will automatically be highlighted when the next release of highlight.js gets published, see: https://github.com/highlightjs/highlight.js/pull/3494
* The `occ` keyword has been added to the above list

**NOTE:**

* This PR is the base that things **CAN** get highlightable correctly. It is essential to use the correct language in the documentation - additional changes may be necessary there. For details using the correct language see the referenced docs PR.
* The descriptions are added intentionally to understand the behaviour and the reason. This info are hard to find and therefore worth to document it here.

**Examples:**
(The examples below already reflect a correct language used)

![image](https://user-images.githubusercontent.com/3321281/156164661-05d29460-a557-41d2-bab2-389970c31900.png)
![image](https://user-images.githubusercontent.com/3321281/156164805-6ecd77cf-a576-492a-8f3f-211550f2dec3.png)

@jnweiger fyi