### PR TITLE
Fix highlight.js XSS / unescaped HTML issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "owncloud-ui",
   "description": "The ownCloud Core documentation",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "AGPL-3.0",
   "author": "The ownCloud Team <docs@owncloud.com>",
   "homepage": "https://github.com/owncloud/docs-ui#readme",
@@ -35,8 +35,13 @@
   "dependencies": {
     "elasticsearch-browser": "^16.7.1",
     "handlebars": "^4.7.7",
-    "highlight.js": "^11.4.0",
+    "highlight.js": "9.18.3",
     "jquery": "^3.6.0"
+  },
+  "dependenciesComments": {
+    "1": "DO NOT use ^9.18.3 for highlight.js because of a compatibility issue with Antora",
+    "2": "Upgrading to a release higher than 9.x will open a XSS vector because the incompatibility",
+    "3": "https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Escape.20content.20in.20source.20block"
   },
   "devDependencies": {
     "@ronilaukkarinen/gulp-stylelint": "^14.0.6",

--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -4,7 +4,7 @@
 // Additional keywords to be highlighted when using the bash language
 // Note that with version 9 of highlight.js, many keywords are missing compared to v10+
 const kwds_bash =
-'occ apt apt-get diff cat chown chmod dpkg exec mkdir systemctl service sudo ssh  touch ' +
+'occ apt apt-get diff cat chown chmod dpkg exec mkdir systemctl sed service sudo ssh touch ' +
 'docker docker-compose find grep make mysql openssl pecl pear php rsync tar wget ' + 
 'a2ensite a2dissite a2enmod a2dismod phpdismod phpenmod';
 

--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -1,18 +1,20 @@
 ;(function () {
   'use strict'
 
-// the following are additional keywords to be highlighted, particulary when using bash
-const CUSTOM_KEYWORDS = ['occ', 'apt', 'apt-get', 'systemctl', 'service', 'sudo',
-'dpkg', 'wget', 'tar', 'mysql', 'php', 'grep', 'pecl', 'pear', 'make', 
-'phpenmod', 'phpdismod', 'a2enmod', 'a2dismod', 'a2ensite', 'a2dissite'];
+// Additional keywords to be highlighted when using the bash language
+// Note that with version 9 of highlight.js, many keywords are missing compared to v10+
+const kwds_bash =
+'occ apt apt-get diff cat chown chmod dpkg exec mkdir systemctl service sudo ssh  touch ' +
+'docker docker-compose find grep make mysql openssl pecl pear php rsync tar wget ' + 
+'a2ensite a2dissite a2enmod a2dismod phpdismod phpenmod';
 
-var hljs = (window.hljs = require('highlight.js/lib/core'))
+// var hljs = (window.hljs = require('highlight.js/lib/core'))
+var hljs = require('highlight.js/lib/highlight')
   hljs.registerLanguage('apache', require('highlight.js/lib/languages/apache'))
   hljs.registerLanguage('asciidoc', require('highlight.js/lib/languages/asciidoc'))
   hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'))
   hljs.registerLanguage('clojure', require('highlight.js/lib/languages/clojure'))
   hljs.registerLanguage('cpp', require('highlight.js/lib/languages/cpp'))
-  hljs.registerLanguage('csharp', require('highlight.js/lib/languages/csharp'))
   hljs.registerLanguage('css', require('highlight.js/lib/languages/css'))
   hljs.registerLanguage('diff', require('highlight.js/lib/languages/diff'))
   hljs.registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'))
@@ -44,22 +46,21 @@ var hljs = (window.hljs = require('highlight.js/lib/core'))
   hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
   hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
 
-/* Add the additional keywords to the bash language
- * References: https://github.com/highlightjs/highlight.js/wiki/Adding-keywords-to-a-language-at-runtime
+/* Add additional keywords to the bash language
+ * Derived from: https://github.com/highlightjs/highlight.js/wiki/Adding-keywords-to-a-language-at-runtime
+ * Note that this is a special version for of highlight.js 9.x which uses strings instead of an array
  * Layout used and defined in highlight.css at .hljs-built_in
 */
-  hljs.getLanguage('bash').keywords.built_in.push(...CUSTOM_KEYWORDS);
-  // console.log(hljs.getLanguage('bash').keywords);
+  hljs.getLanguage('bash').keywords.built_in += ' ' + kwds_bash;
+  // console.log(hljs.getLanguage('bash').keywords.built_in);
 
-/* To eliminate the security messages in the browser telling:
- * "One of your code blocks includes unescaped HTML. This is a potentially serious security risk"
- * See: https://github.com/highlightjs/highlight.js/wiki/security
- * A hljs command has been added in partials/footer-scripts.hbs
- * hljs.configure({ ignoreUnescapedHTML: true })
- * This is not a security issue for us as we have a static site
+/* Do the same pattern matching as with version 11 of highlight.js
+ * See: https://github.com/highlightjs/highlight.js/pull/3494
 */
+  hljs.getLanguage('bash').lexemes = /\b[a-z][a-z0-9._-]+\b/;
+  // console.log(hljs.getLanguage('bash').lexemes);
+
   ;[].slice.call(document.querySelectorAll('pre code.hljs')).forEach(function (node) {
-    hljs.highlightElement(node)
+    hljs.highlightBlock(node)
   })
 })()
-

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -2,6 +2,6 @@
 {{#if env.ELASTICSEARCH_NODE}}
   <script src="{{uiRootPath}}/js/vendor/elastic.js"></script>
 {{/if}}
-<script src="{{uiRootPath}}/js/vendor/highlight.js"></script>
-<script>hljs.highlightAll()</script>
-<script>hljs.configure({ ignoreUnescapedHTML: true })</script>
+<script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
+{{! This is highlight.js v9.x syntax DON NOT upgrade to 10+}}
+{{! Also see package.json for details}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,10 +2894,10 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-highlight.js@^11.4.0:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.4.0.tgz#34ceadd49e1596ee5aba3d99346cdfd4845ee05a"
-  integrity sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==
+highlight.js@9.18.3:
+  version "9.18.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.3.tgz#a1a0a2028d5e3149e2380f8a865ee8516703d634"
+  integrity sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-ui/issues/437 (Escape the HTML within code blocks)
References: https://github.com/owncloud/docs-ui/pull/435 (Fix and improve highlighting with highlight.js)

When package.json was defined in the initial setup, `highlight.js` was not limited to the major version 9.

When the time passed by, `highlight.js` published two major release with twice a lot of backend changes which were incompatible with Antora. The crucial upgrade from v9 to v10 was made on 20 Dec 2020 with PR: [([Security] Bump highlight.js from 9.18.1 to 10.4.1)](https://github.com/owncloud/docs-ui/pull/224). As there was no upgrade limitation set in package.json, CI reported a go and no other obstacles were known at the time of reading, the PR got merged.

Note that it is a good advice to regulary check the Antora Default UI for changes...

Funnily nobody identified the XSS / unescaped HTML issue which was printed in the browsers console...

With a discussion in the Antora channel [Escape content in source block](https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Escape.20content.20in.20source.20block), it turned out which issue we have and that we have to revert to highlight.js v9 **AND** avoid any upgrade for the time being.

This PR:
* Fixes the XSS issue by going back and fixing the version of highlight.js to v9.18.3 (supported by Antora)
* Updates the pattern match regex for bash to be up-to-date with the upcoming v11 release
* Adds and updates the keywords of bash to a more close version of v11

Note that the comments written are intentionally to avoid an accidentially update of highlight.js.

@jnweiger fyi (as discussed)