### PR TITLE
Update highlight.js

### DIFF
--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -3,7 +3,8 @@
 
 // the following are additional keywords to be highlighted, particulary when using bash
 const kwds_bash = [
-'occ', 'apt', 'apt-get', 'curl', 'diff', 'dpkg', 'find', 'grep', 'install',
+'occ', 'ocis',
+'apt', 'apt-get', 'curl', 'diff', 'dpkg', 'find', 'grep', 'install',
 'make', 'mysql', 'openssl', 'pear', 'pecl', 'php', 'rsync',
 'service', 'systemctl', 'ssl', 'ssh', 'sudo', 'tar', 'wget',
 'yum', 'zypper',


### PR DESCRIPTION
Adding ocis to the list of key words to be highlighted when using bash - used for the ocis documentation.