### PR TITLE
Add package medium-zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Finally, run the following command to install all dependencies:
 yarn install
 ```
 
+### Add Packages
+
+If a new package needs to be added, type the following:
+
+```Shell
+yarn add <package-name>
+```
+
 ## Prepared Yarn Commands
 
 To get all prepared yarn commands run the following command:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "elasticsearch-browser": "^16.7.1",
     "handlebars": "^4.7.7",
     "highlight.js": "^11.5.1",
-    "jquery": "^3.6.0"
+    "jquery": "^3.6.0",
+    "medium-zoom": "^1.0.6"
   },
   "devDependencies": {
     "@ronilaukkarinen/gulp-stylelint": "^14.0.6",

--- a/src/css/medium-zoom.css
+++ b/src/css/medium-zoom.css
@@ -1,0 +1,4 @@
+.medium-zoom-overlay,
+img.medium-zoom-image {
+  z-index: 1000;
+}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -14,3 +14,4 @@
 @import "highlight.css";
 @import "tabs.css";
 @import "owncloud.css";
+@import "medium-zoom.css";

--- a/src/js/vendor/medium-zoom.js
+++ b/src/js/vendor/medium-zoom.js
@@ -1,0 +1,9 @@
+;(function () {
+  var Mzm = (window.mzm = require('medium-zoom/dist/medium-zoom.min'))
+  // 'span.image img'
+  //    css selector that medium-zoom connects for standard images like jpg or png
+  // 'div.imageblock img'
+  //    css selector that medium-zoom connects for svg images
+  // with that, there is no need to define a role in the image for zooming - all images are zoomable !
+  Mzm('span.image img, div.imageblock img', { background: '#fff' })
+})()

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -5,3 +5,4 @@
 <script src="{{uiRootPath}}/js/vendor/highlight.js"></script>
 <script>hljs.highlightAll()</script>
 <script>hljs.configure({ ignoreUnescapedHTML: true })</script>
+<script async src="{{{uiRootPath}}}/js/vendor/medium-zoom.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3703,6 +3703,11 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
+medium-zoom@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.0.6.tgz#9247f21ca9313d8bbe9420aca153a410df08d027"
+  integrity sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg==
+
 meow@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"


### PR DESCRIPTION
Fixes: #488 (Zoomable, clickable diagrams)

This PR adds the `medium-zoom` package.

The package allows to zoom an image to full screen by clicking on it which makes it easier to read images. This package was disussed in the Antora-Zulip Chat, see issue link above.

For an example see the following link, the page is created with Antora: https://neo4j.com/docs/aura/aurads/architecture/#_graph_data_flow

