### PR TITLE
Adding a marging around the zoomed image

### DIFF
--- a/src/js/vendor/medium-zoom.js
+++ b/src/js/vendor/medium-zoom.js
@@ -5,5 +5,5 @@
   // 'div.imageblock img'
   //    css selector that medium-zoom connects for svg images
   // with that, there is no need to define a role in the image for zooming - all images are zoomable !
-  Mzm('span.image img, div.imageblock img', { background: '#fff' })
+  Mzm('span.image img, div.imageblock img', { background: '#fff', margin: 10 })
 })()


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-ui/pull/491 (https://github.com/owncloud/docs-ui/pull/491)

Adding a marging around the zoomed image.

If an image has content to each side, it would fill the browser window also to the edges. This PR adds a margin making the image looking better in the browser window and not so squeezed in.
