### PR TITLE
Fix the colors for IMPORTANT and WARNING

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -247,23 +247,28 @@
 }
 
 .doc .admonitionblock.caution .icon {
+  /* base.css */
   background-color: #a0439c;
 }
 
 .doc .admonitionblock.important .icon {
-  background-color: #d32f2f;
+  /* orange */
+  background-color: #e18114;
 }
 
 .doc .admonitionblock.note .icon {
+  /* blue */
   background-color: #217ee7;
 }
 
 .doc .admonitionblock.tip .icon {
+  /* green */
   background-color: #41af46;
 }
 
 .doc .admonitionblock.warning .icon {
-  background-color: #e18114;
+  /* red */
+  background-color: #d32f2f;
 }
 
 .doc .admonitionblock .icon i {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -247,7 +247,7 @@
 }
 
 .doc .admonitionblock.caution .icon {
-  /* base.css */
+  /* pink */
   background-color: #a0439c;
 }
 


### PR DESCRIPTION
The colors were switched before, now they are correct:
![image](https://user-images.githubusercontent.com/3321281/230727463-99f2a81a-e886-4415-9e98-5098be5b381e.png)
I also added a comment for each admonitionblock to identify its color quickly.