### PR TITLE
Prepare stylelint upgrade - update media notation

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -24,7 +24,7 @@ html {
   text-size-adjust: 100%;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (width >= 1024px) {
   html {
     font-size: 1.2em;
   }

--- a/src/css/breadcrumbs.css
+++ b/src/css/breadcrumbs.css
@@ -6,7 +6,7 @@
   hyphens: none;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (width >= 1024px) {
   .crumbs {
     display: block;
   }

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -4,7 +4,7 @@
   padding: 0 1rem 4rem;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (width >= 1024px) {
   .doc {
     margin: 0 2rem;
     max-width: 54rem;

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -60,7 +60,7 @@ body {
   padding: 0 0.375rem;
 }
 
-@media screen and (min-width: 800px) {
+@media screen and (width >= 800px) {
   .navbar-end > .navbar-item,
   .navbar-end .navbar-link {
     color: var(--color-navbar-text);
@@ -176,7 +176,7 @@ body {
   margin: 0.25rem 0;
 }
 
-@media screen and (max-width: 799px) {
+@media screen and (width >= 799px) {
   .navbar-brand .navbar-item {
     align-items: center;
     display: flex;
@@ -221,7 +221,7 @@ body {
   }
 }
 
-@media screen and (min-width: 800px) {
+@media screen and (width >= 800px) {
   .navbar,
   .navbar-menu,
   .navbar-end {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 800px) {
+@media screen and (width >= 800px) {
   .main-wrapper {
     display: flex;
   }

--- a/src/css/navigation-explore.css
+++ b/src/css/navigation-explore.css
@@ -22,7 +22,7 @@
   height: var(--drawer-height);
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (width >= 1024px) {
   .navigation-explore .context {
     font-size: 0.75rem;
   }

--- a/src/css/navigation-menu.css
+++ b/src/css/navigation-menu.css
@@ -11,7 +11,7 @@ html.is-clipped--nav {
   height: calc ( 100vh - var(--navbar-height) - var(--toolbar-height) - var(--drawer-height));
 }
 
-@media screen and (min-width: 800px) {
+@media screen and (width >= 800px) {
   .navigation-menu {
     height: calc(100vh - var(--navbar-height) - var(--drawer-height));
   }

--- a/src/css/navigation.css
+++ b/src/css/navigation.css
@@ -16,14 +16,14 @@
   display: block;
 }
 
-@media screen and (min-width: 769px) {
+@media screen and (width >= 769px) {
   .navigation-container {
     width: 16rem;
     font-size: 0.875rem;
   }
 }
 
-@media screen and (min-width: 800px) {
+@media screen and (width >= 800px) {
   .navigation-container {
     font-size: 0.8125rem;
     flex: none;
@@ -40,13 +40,13 @@
   height: calc(100vh - var(--navbar-height) - var(--toolbar-height));
 }
 
-@media screen and (min-width: 769px) {
+@media screen and (width >= 769px) {
   .navigation {
     box-shadow: 0.5px 0 3px #c1c1c1;
   }
 }
 
-@media screen and (min-width: 800px) {
+@media screen and (width >= 800px) {
   .navigation {
     top: var(--navbar-height);
     box-shadow: none;

--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -129,7 +129,7 @@ blockquote::before {
 /**
  * Supplemental Responsive Styles
  */
-@media screen and (max-width: 600px) {
+@media screen and (width >= 600px) {
   footer div.container div.row-full {
     margin-left: 0;
     width: 100%;
@@ -142,7 +142,7 @@ blockquote::before {
   }
 }
 
-@media screen and (min-width: 601px) {
+@media screen and (width >= 601px) {
   footer div.container div.row-full {
     margin-left: 0;
     width: 100%;

--- a/src/css/page-versions.css
+++ b/src/css/page-versions.css
@@ -4,7 +4,7 @@
   line-height: 1;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (width >= 1024px) {
   .page-versions {
     margin-right: 0.7rem;
   }

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -38,7 +38,7 @@
   border: none;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (width >= 1024px) {
   .navigation-toggle {
     display: none;
   }
@@ -68,7 +68,7 @@
   padding-right: 0.5rem;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (width >= 1024px) {
   .edit-this-page {
     display: block;
   }


### PR DESCRIPTION
Our current notation for css media features looks like:

```
@media (min-width: 600px) {}
/**    ↑
 *     Thise is a media feature notation */ 
```
This is an [older notation](https://stylelint.io/user-guide/rules/media-feature-range-notation/) and when upgrading to `stylelint v15` (upcomping PR), we get `yarn bundle errors` like:

```
src/css/base.css
 27:19  ✖  Expected "context" media feature range notation  media-feature-range-notation
```

To use `stylelint v15`, we must update the css lines to the current notation accordingly like `@media (width >= 600px) {}`

Note that this does not change anything bundle wise or rendering wise. It is just a preperation to make the upcoming stylelint PR passing smooth.