### PR TITLE
Update the fragmentation jumper java script

### DIFF
--- a/src/js/03-fragment-jumper.js
+++ b/src/js/03-fragment-jumper.js
@@ -3,6 +3,7 @@
 
   var article = document.querySelector('article.doc')
   var toolbar = document.querySelector('.toolbar')
+  var supportsScrollToOptions = 'scrollTo' in document.documentElement
 
   function decodeFragment (hash) {
     return hash && (~hash.indexOf('%') ? decodeURIComponent(hash) : hash).slice(1)
@@ -18,14 +19,16 @@
       window.location.hash = '#' + this.id
       e.preventDefault()
     }
-    window.scrollTo(0, computePosition(this, 0) - toolbar.getBoundingClientRect().bottom)
+    var y = computePosition(this, 0) - toolbar.getBoundingClientRect().bottom
+    var instant = e === false && supportsScrollToOptions
+    instant ? window.scrollTo({ left: 0, top: y, behavior: 'instant' }) : window.scrollTo(0, y)
   }
 
   window.addEventListener('load', function jumpOnLoad (e) {
     var fragment, target
     if ((fragment = decodeFragment(window.location.hash)) && (target = document.getElementById(fragment))) {
-      jumpToAnchor.bind(target)()
-      setTimeout(jumpToAnchor.bind(target), 0)
+      jumpToAnchor.call(target, false)
+      setTimeout(jumpToAnchor.bind(target, false), 250)
     }
     window.removeEventListener('load', jumpOnLoad)
   })


### PR DESCRIPTION
The fragmentaion jumper script got updated, see:
https://gitlab.com/antora/antora-ui-default/-/tree/master/src/js?ref_type=heads

Based on a discussion seen on Antora/Zulip [Bug: UI-clicking an xref to anchor scrolls past anchor.](https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Bug.3A.20UI-clicking.20an.20xref.20to.20anchor.20scrolls.20past.20anchor.2E)

Intensively tested via a full build on staging.