### PR TITLE
Fix a css setting in docs.css

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -126,7 +126,8 @@
   margin: 1rem 0 0;
 }
 
-.doc table.tableblock + * {
+/* do not use '.doc table.tableblock + * {' as it will render font sizes not correctly */
+.doc table.tableblock {
   border-collapse: collapse;
   font-size: 0.8em;
   margin-top: 2rem 0;


### PR DESCRIPTION
References: #699

We need to undo the small change made as font sizes get inconstistent in some tab situations.

(This css upgrade stuff drives me nuts...)