### PR TITLE
edith-this-page.hbs update

### DIFF
--- a/src/partials/edit-this-page.hbs
+++ b/src/partials/edit-this-page.hbs
@@ -1,3 +1,5 @@
-  {{#if page.editUrl}}
+  {{#if (and page.fileUri (not env.CI))}}
+    <div class="edit-this-page"><a href="{{page.fileUri}}" rel="noopener noreferrer" target="_blank">Edit this Page</a></div>
+  {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
     <div class="edit-this-page"><a href="{{page.editUrl}}" rel="noopener noreferrer" target="_blank">Edit this Page</a></div>
   {{/if}}


### PR DESCRIPTION
References:
https://gitlab.com/antora/antora-ui-default/-/commit/74a3f8af3115be2c9f82e951e511a9578984a2ab
https://docs.antora.org/antora-ui-default/templates/

Found while reading the default-ui in gitlab.

Our handlebar definition for edith-this-page was outdated.
The new version now covers the situation when having a private repo (which may come in the future), no editing is possible. A ordinary reader cant access a private repo. Optional envvars are described in the linked Antora documentation.

Locally tested - ok.
