### PR TITLE
Add the capability for custom markers in unordered lists

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -352,9 +352,43 @@
   padding: 0 0 0 2rem;
 }
 
-.doc ul.checklist {
-  padding-left: 0.5rem;
-  list-style: none;
+.doc ul.checklist,
+.doc ul.none,
+.doc ol.none,
+.doc ul.no-bullet,
+.doc ol.unnumbered,
+.doc ul.unstyled,
+.doc ol.unstyled {
+  list-style-type: none;
+/*  padding-left: 0.5rem; */
+}
+
+.doc ul.no-bullet,
+.doc ol.unnumbered {
+  padding-left: 1.25rem;
+}
+
+.doc ul.unstyled,
+.doc ol.unstyled {
+  padding-left: 0;
+}
+
+.doc ul.circle {
+  list-style-type: circle;
+}
+
+.doc ul.disc {
+  list-style-type: disc;
+}
+
+.doc ul.square {
+  list-style-type: square;
+}
+
+.doc ul.circle ul:not([class]),
+.doc ul.disc ul:not([class]),
+.doc ul.square ul:not([class]) {
+  list-style: inherit;
 }
 
 .doc ul.checklist p > i.fa-check-square-o:first-child,


### PR DESCRIPTION
References: [Antora-docs Custom markers](https://docs.asciidoctor.org/asciidoc/latest/lists/unordered/#custom-markers)

We were missing that in our current CSS though possible in the Antora docs.
With that, we are a bit more aligned with Antoras default UI... 