### PR TITLE
Add some asciidoc role css

### DIFF
--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -127,6 +127,25 @@ blockquote::before {
 }
 
 /**
+ * The following three selectors origin from the asciidoc css stylesheet:
+ * https://github.com/asciidoctor/asciidoctor/blob/main/src/stylesheets/asciidoctor.css
+ * They enable using roles like for tables as described in:
+ * https://docs.asciidoctor.org/asciidoc/latest/tables/table-ref/
+ */
+.center {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.left {
+  float: left !important;
+}
+
+.right {
+  float: right !important;
+}
+
+/**
  * Supplemental Responsive Styles
  */
 @media screen and (width <= 600px) {


### PR DESCRIPTION
While working on a PR in `docs-server`, I identified that roles (= css rules) manually assigned to a table according the [asciidoc documentation](https://docs.asciidoctor.org/asciidoc/latest/tables/table-ref/) are not used. This leaded to a question in the [Antora Zulip channel](https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Centering.20a.20complete.20table.20.28contents.20works.29) and an answer how to solve that. To make the required roles work, I needed to add some [asciidoc stylsheet css](https://github.com/asciidoctor/asciidoctor/blob/main/src/stylesheets/asciidoctor.css) (`.center`, `.left`, `.right`) to our UI.

Tested and works great.