### PR TITLE
Set the correct nodejs version for bundling

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -40,9 +40,11 @@ def main(ctx):
             },
             {
                 "name": "Build",
-                "image": "owncloudci/nodejs:16",
+                "image": "owncloudci/nodejs:18",
                 "commands": [
                     "yarn bundle",
+                    "file build/ui-bundle.zip",
+                    "ls -l build/ui-bundle.zip"
                 ],
             },
             {


### PR DESCRIPTION
This PR fixes two issues:

* The `yarn bundle` step had the wrong node version configured.
The version is now aligned with the other build steps (node v18)
* When the bundle step produces a zip file that does not error but does not have the correct file size compared to a local build, we can now identify this because the filesize gets printed in the build step.

Note that this PR does not fix any build issues, but we now can identify them more easily.