### PR TITLE
Fix toolbox overlay on small screen width and make copy button white …

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -554,7 +554,7 @@
 }
 
 .doc .source-toolbox img.copy-icon {
-  filter: invert(50.2%);
+  filter: invert(100%);
 }
 
 .doc .source-toolbox svg.copy-icon {
@@ -702,4 +702,6 @@ kbd,
 .hljs {
   font-size: 0.7rem;
   border-radius: 4px;
+  /* Adjustments to prevent toolbox and content overlay on small screen width */
+  padding-top: 2em !important;
 }


### PR DESCRIPTION
- Fix toolbox overlay with code on small screen width
- Fix toolbox copy button appear as disabled (grey), adjusted to white color 