### PR TITLE
Add gray-light as color to the selectable color roles

### DIFF
--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -234,6 +234,14 @@ blockquote::before {
   background: #7d7d7d;
 }
 
+.gray-light {
+  color: #bfbfbf;
+}
+
+.gray-light-background {
+  background: #d9d9d9;
+}
+
 .green {
   color: #006000;
 }


### PR DESCRIPTION
This PR adds `gray-light` and `gray-light-background` as selectable color roles to our css.