### PR TITLE
Make 'search' a Class with a distinctive name and not an ID

### DIFF
--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -110,7 +110,7 @@ blockquote::before {
   text-align: justify;
 }
 
-#search {
+.search-input {
   display: inline-flex;
   background-color: #fff;
   border: 1px solid #e1e1e1;

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -17,6 +17,7 @@
             <span class="control">
               <input
                 id="search"
+                class="search-input"
                 type="text"
                 placeholder="Search"
                 data-host="{{env.ELASTICSEARCH_NODE}}"


### PR DESCRIPTION
When using the term `search` as section heading, it was rendered as the search field which was not correct.

With this change, `search` got renamed to `search-input` and transformed to a class which is referenced by the elastic search code correctly.

Tested with a local build including ES integration - works fine.

Many thanks to @AlexAndBear for the help finding and fixing this!