### PR TITLE
Fix listing block title color

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -435,7 +435,8 @@
 .doc .listingblock .title,
 .doc .openblock .title {
   /* color: #4a4a4a; */
-  color: #191919;
+  /* color: #191919; */
+  color: #7a2518;
   font-size: 0.925rem;
   font-style: italic;
   letter-spacing: -0.005em;


### PR DESCRIPTION
This PR makes the listing block title color the same as we have when using a title in tables