### PR TITLE
Add the tslib dependency required for prettier-eslint 16.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "require-from-string": "^2.0.1",
         "standard": "^17.1.2",
         "stylelint-config-standard": "^34.0.0",
+        "tslib": "^2.8.1",
         "typeface-open-sans": "^1.1.13",
         "typeface-roboto-mono": "^1.1.13",
         "vinyl-buffer": "^1.0.0"
@@ -9242,9 +9243,9 @@
       }
     },
     "node_modules/prettier-eslint": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.3.2.tgz",
-      "integrity": "sha512-KwT/YWoJGbogsHLZ+Rji8ih6JaUqoA8Z4PAxomcVWhq3gYp5jXgSS/BzB3tm6lWS+Hd4VBF81jqMrdJhXKkhcg==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.4.1.tgz",
+      "integrity": "sha512-qf8Grhq68kg0tyhXVik2aOx72W8Jxre2ABXgV1pC3OCb3jOo40UZuvk3f/I3/ZA7Qw6qydZX4b7ySSCSgv4/8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9262,6 +9263,9 @@
       },
       "engines": {
         "node": ">=16.10.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier-eslint"
       },
       "peerDependencies": {
         "prettier-plugin-svelte": "^3.0.0",
@@ -11988,6 +11992,13 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
       "dev": true,
@@ -12113,7 +12124,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "require-from-string": "^2.0.1",
     "standard": "^17.1.2",
     "stylelint-config-standard": "^34.0.0",
+    "tslib": "^2.8.1",
     "typeface-open-sans": "^1.1.13",
     "typeface-roboto-mono": "^1.1.13",
     "vinyl-buffer": "^1.0.0"


### PR DESCRIPTION
This PR adds the tslib dependency required for prettier-eslint 16.4.1 which is required for:
#867 (chore(deps-dev): bump prettier-eslint from 16.3.2 to 16.4.1)

Tested locally together with #867, works.
After merging, we can rebase #867 and merge that one.