### PR TITLE
chore(deps-dev): bump prettier-eslint from 16.3.2 to 16.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "postcss-custom-properties": "^14.0.4",
         "postcss-import": "^16.1.0",
         "postcss-url": "^10.1.3",
-        "prettier-eslint": "^16.3.2",
+        "prettier-eslint": "^16.4.1",
         "require-from-string": "^2.0.1",
         "standard": "^17.1.2",
         "stylelint-config-standard": "^34.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "postcss-custom-properties": "^14.0.4",
     "postcss-import": "^16.1.0",
     "postcss-url": "^10.1.3",
-    "prettier-eslint": "^16.3.2",
+    "prettier-eslint": "^16.4.1",
     "require-from-string": "^2.0.1",
     "standard": "^17.1.2",
     "stylelint-config-standard": "^34.0.0",


### PR DESCRIPTION
References: #867 
dependabot got confused and closed the referenced PR instead of rebasing and taking the change...