### PR TITLE
Add CSS for color, title and font

### DIFF
--- a/src/css/owncloud-vars.css
+++ b/src/css/owncloud-vars.css
@@ -12,6 +12,7 @@
   --doc-max-width--desktop: 100%;
 
   /* owncloud additions */
+  --color-title: #7a2518;
   --color-navbar-bg: #1b223d;
   --color-navbar-bg-focus: #0e152d;
   --navbar-height-5xx: calc(80 / var(--rem-base) * 1rem);

--- a/src/css/owncloud.css
+++ b/src/css/owncloud.css
@@ -124,7 +124,12 @@
 .doc .openblock .title,
 .doc .videoblock .title,
 .doc table.tableblock caption {
-  color: #7a2518;
+  color: var(--color-title);
+}
+
+.doc .olist .title,
+.doc .ulist .title {
+  color: var(--color-title);
 }
 
 /* Other possible colors #248232 (dark green) #2ba84a (brighter green), */
@@ -228,9 +233,10 @@
  * color: #8c8c8c;
  */
 div.paragraph div.title {
-  color: #7a2518;
-  font-size: 85%;
-  font-style: italic;
+  color: var(--color-title);
+  /* font-size: 85%; */
+  font-weight: var(--caption-font-weight);
+  font-style: var(--caption-font-style);
   padding: 2px;
   text-align: left;
 }
@@ -239,7 +245,7 @@ div.paragraph div.title {
  * dlist title same as div.paragraph title
  */
 div.dlist div.title {
-  color: #7a2518;
+  color: var(--color-title);
   font-size: 85%;
   font-style: italic;
   padding: 2px;
@@ -261,8 +267,9 @@ div.dlist div.title {
 caption {
   display: table-caption;
   text-align: left;
-  color: #7a2518;
+  color: var(--color-title);
 }
+
 
 /**
  * Supplemental Navigation Styles


### PR DESCRIPTION
This PR adds some css for color, title and font.

Found while working on a `docs-ocis` PR.

Tested locally, works fine.