### PR TITLE
fix: use .nojekyll because of GH Pages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
       "imports": "only-multiline",
       "exports": "only-multiline"
     }],
-    "max-len": [1, 120, 2],
+    "max-len": [1, 130, 2],
     "space-before-function-paren": "off"
   }
 }

--- a/src/ui.yml
+++ b/src/ui.yml
@@ -19,6 +19,7 @@ static_files:
 - mstile-150x150.png
 - mstile-310x150.png
 - mstile-310x310.png
+- .nojekyll
 - opengraph-android.png
 - opengraph-branding.png
 - opengraph-default.png


### PR DESCRIPTION
References: https://docs.antora.org/antora/latest/publish-to-github-pages/

There is an issue when publishing to GH Pages according the reference above. This PR fixes this issue.
