### PR TITLE
fix(search): use absolute bundle-path for Pagefind Component UI

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -6,11 +6,12 @@
             <span class="navbar-title">{{site.title}}</span>
           </a>
           <div class="navbar-item search">
-            {{!-- Pagefind Component UI modal search. pagefind-config points the
-                  components at the index emitted by `pagefind --site` under
-                  siteRootPath; the trigger button opens the modal overlay (also
-                  via the Ctrl/Cmd+K shortcut). --}}
-            <pagefind-config bundle-path="{{{siteRootPath}}}/pagefind/"></pagefind-config>
+            {{!-- Pagefind Component UI modal search. The trigger opens the modal
+                  overlay (also via Ctrl/Cmd+K). bundle-path MUST be absolute/root-
+                  relative: the components dynamic-import() pagefind.js relative to
+                  pagefind-component-ui.js's URL, so a page-relative "./pagefind/"
+                  (siteRootPath on shallow pages) doubles to /pagefind/pagefind/. --}}
+            <pagefind-config bundle-path="/pagefind/"></pagefind-config>
             <pagefind-modal-trigger></pagefind-modal-trigger>
             <pagefind-modal reset-on-close></pagefind-modal>
           </div>


### PR DESCRIPTION
## Problem

Pagefind search fails on `doc.owncloud.com` — opening the search modal shows **"Pagefind Error: Could not load search bundle"**. The browser requests `/pagefind/pagefind/pagefind.js` (a doubled `pagefind/` segment) which 404s (served as `text/html`), so the dynamically imported module is blocked.

This affects shallow pages such as the **site homepage**; deeper pages happened to work, which masked the bug.

## Root cause

The modal Component UI was configured with a **page-relative** `bundle-path`:

```hbs
<pagefind-config bundle-path="{{{siteRootPath}}}/pagefind/"></pagefind-config>
```

The components load the index via a dynamic `import(\`${bundlePath}pagefind.js\`)` that executes **inside** `/pagefind/pagefind-component-ui.js`. A dynamic `import()` resolves relative specifiers against the **importing module's URL**, not the page. On shallow pages `siteRootPath` is `.`, so `./pagefind/` resolves against `…/pagefind/` and doubles to `…/pagefind/pagefind/pagefind.js`.

Verified against production:

| URL | Status |
|---|---|
| `/pagefind/pagefind.js` | `200` ✓ |
| `/pagefind/pagefind/pagefind.js` | `404` (text/html) |

## Fix

Use an absolute, root-relative `bundle-path="/pagefind/"`. It is depth-independent and matches Pagefind's documented convention (their examples use absolute paths; auto-detect also falls back to `/pagefind/`).

One-line template change; `npm run lint` passes on Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)